### PR TITLE
feat: ability to set custom message resolvers

### DIFF
--- a/input.go
+++ b/input.go
@@ -48,6 +48,12 @@ func IOptPrivateOnly(b bool) InputOption {
 	}
 }
 
+func IOptValueResolver(fn ValueResolver) InputOption {
+	return func(ip *Input) {
+		ip.valueResolverFn = fn
+	}
+}
+
 // NewInput text creates a new text input, optionally chaining with the `next`
 // handler. One must use Handle as a handler for bot endpoint, and then hook the
 // OnText to OnTextMw.  TextCallbacker.Text should produce the text that user
@@ -72,10 +78,6 @@ func NewInput(name string, tc TextCallbacker, opts ...InputOption) *Input {
 // onTextFn should return InputError if the user input is not valid.
 func NewInputText(name string, text string, onTextFn HandleContextFunc, opts ...InputOption) *Input {
 	return NewInput(name, NewStaticTVC(text, nil, onTextFn), opts...)
-}
-
-func (ip *Input) SetValueResolver(fn ValueResolver) {
-	ip.valueResolverFn = fn
 }
 
 func (ip *Input) Handler(c tb.Context) error {


### PR DESCRIPTION
I wanted to be able to set values other than just `Message().Text` like Location, etc

This was the fastest way to add that in, basically by enhancing the input class, however if you think of better ways let me know!